### PR TITLE
Also search %PATH% for sqlpackage.exe

### DIFF
--- a/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
+++ b/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
@@ -133,7 +133,22 @@ function Invoke-SqlPackage {
 
     Invoke-TimeSignal -Start
 
-    if (!(Test-PathExists -Path $executable -Type Leaf)) { return }
+    if (!(Test-PathExists -Path $executable -Type Leaf)){
+        try{
+            $envSqlPackage = (Get-Command -Name "sqlpackage.exe").Source
+            if (!(Test-PathExists -Path $envSqlPackage -Type Leaf)) { return }
+            else{ 
+                $executable = $envSqlPackage
+                Set-D365SqlPackagePath -Path $executable
+            }            
+        }
+        catch
+        {
+            # SqlPackage.exe is not in $Script:SqlPackagePath
+            # and not in %PATH%, so
+            return
+        }
+    }
 
     Write-PSFMessage -Level Verbose -Message "Starting to prepare the parameters for sqlpackage.exe"
 

--- a/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
+++ b/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
@@ -137,10 +137,10 @@ function Invoke-SqlPackage {
         try{
             $envSqlPackage = (Get-Command -Name "sqlpackage.exe").Source
             if (!(Test-PathExists -Path $envSqlPackage -Type Leaf)) { return }
-            else{ 
+            else{
                 $executable = $envSqlPackage
                 Set-D365SqlPackagePath -Path $executable
-            }            
+            }
         }
         catch
         {


### PR DESCRIPTION
The installation documentation for SqlPackage says: Installing SqlPackage as a global tool makes it available on your path as sqlpackage and is the recommended method to install SqlPackage for Windows, macOS, and Linux.

In line with Microsoft's expectations, also search %PATH% if sqlpackage is not found in the d365fo.tools default path ($Script:SqlPackagePath). If it is found in the %PATH% then update the default path with the actual path to sqlpackage.exe.

Author: Colin Daley
Date: 2024-03-24