### PR TITLE
Fix Invoke-D365SDPInstallUDE to handle updates and require admin privileges

### DIFF
--- a/d365fo.tools/functions/invoke-d365sdpinstallude.ps1
+++ b/d365fo.tools/functions/invoke-d365sdpinstallude.ps1
@@ -103,6 +103,13 @@ function Invoke-D365SDPInstallUDE {
           return
       }
 
+      # Delete existing module folder if it exists
+      $moduleFolderPath = Join-Path -Path $MetaDataDir -ChildPath $($_.Name)
+      if (Test-Path -Path $moduleFolderPath) {
+          Remove-Item -Path $moduleFolderPath -Recurse -Force
+          Write-PSFMessage -Level Verbose -Message "Deleted existing module folder $moduleFolderPath"
+      }
+
       # Unzip to $MetaDataDir
       $moduleZipPath = Join-Path -Path $MetaDataDir -ChildPath $($_.Name)
       Expand-Archive -Path $moduleZip.FullName -DestinationPath $moduleZipPath


### PR DESCRIPTION
Add logic to delete existing module folders before extracting new ones in `invoke-d365sdpinstallude.ps1`.

* Delete existing module folder if it exists before unzipping the new module.
* Add verbose message to indicate deletion of existing module folder.
* Adjust indentation and add missing newline at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FH-Inway/d365fo.tools/pull/130?shareId=72e64ec3-0494-46b1-beed-248f3f79e2af).